### PR TITLE
QueryManager is coming !

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -275,6 +275,11 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -143,6 +143,7 @@ public final class SystemSessionProperties
     public static final String MAX_UNACKNOWLEDGED_SPLITS_PER_TASK = "max_unacknowledged_splits_per_task";
     public static final String MERGE_PROJECT_WITH_VALUES = "merge_project_with_values";
     public static final String TIME_ZONE_ID = "time_zone_id";
+    public static final String OPTIMIZE_TESSERACT_QUERIES = "optimize-tesseract-queries";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -660,6 +661,11 @@ public final class SystemSessionProperties
                                 getTimeZoneKey(value);
                             }
                         },
+                        true),
+                booleanProperty(
+                        OPTIMIZE_TESSERACT_QUERIES,
+                        "Query Manager for Tesseract is enabled or not",
+                        featuresConfig.isOptimizeTesseractQueries(),
                         true));
     }
 
@@ -1173,4 +1179,10 @@ public final class SystemSessionProperties
     {
         return Optional.ofNullable(session.getSystemProperty(TIME_ZONE_ID, String.class));
     }
+
+    public static boolean isOptimizeTesseractQueries(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZE_TESSERACT_QUERIES, Boolean.class);
+    }
+
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -102,7 +102,7 @@ public class QueryStateMachine
     private static final Logger QUERY_STATE_LOG = Logger.get(QueryStateMachine.class);
 
     private final QueryId queryId;
-    private final String query;
+    private String query;
     private final Optional<String> preparedQuery;
     private final Session session;
     private final URI self;
@@ -266,6 +266,14 @@ public class QueryStateMachine
         queryStateMachine.addStateChangeListener(newState -> QUERY_STATE_LOG.debug("Query %s is %s", queryStateMachine.getQueryId(), newState));
 
         return queryStateMachine;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
     }
 
     public QueryId getQueryId()

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -160,6 +160,11 @@ public interface Metadata
     ColumnMetadata getColumnMetadata(Session session, TableHandle tableHandle, ColumnHandle columnHandle);
 
     /**
+     * initializes the RDBMS connection properties required to fetch tesseract metadata
+     */
+    default void initializeTesseractMetadataConfig(Session session, TableHandle tableHandle){}
+
+    /**
      * Gets the columns metadata for all tables that match the specified prefix.
      * TODO: consider returning a stream for more efficient processing
      */

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -608,6 +608,14 @@ public final class MetadataManager
     }
 
     @Override
+    public void initializeTesseractMetadataConfig(Session session, TableHandle tableHandle)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+        metadata.initializeTesseractMetadataConfig(session.toConnectorSession(catalogName));
+    }
+
+    @Override
     public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -40,6 +40,7 @@ import io.trino.spi.eventlistener.TableInfo;
 import io.trino.spi.security.Identity;
 import io.trino.spi.type.Type;
 import io.trino.sql.analyzer.ExpressionAnalyzer.LabelPrefixedReference;
+import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.ExistsPredicate;
@@ -71,6 +72,7 @@ import io.trino.sql.tree.Unnest;
 import io.trino.sql.tree.WindowFrame;
 import io.trino.sql.tree.WindowOperation;
 import io.trino.transaction.TransactionId;
+import tesseract.pojos.TesseractAnalysisContext;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -213,11 +215,19 @@ public class Analysis
     private final Multimap<Field, SourceColumn> originColumnDetails = ArrayListMultimap.create();
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
 
+    // to create a binding between a planNodeId and AST
+    private final Map<PlanNodeId, TesseractAnalysisContext> tableScanNodesToLocationInfo = new LinkedHashMap<>();
+
     public Analysis(@Nullable Statement root, Map<NodeRef<Parameter>, Expression> parameters, boolean isDescribe)
     {
         this.root = root;
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.isDescribe = isDescribe;
+    }
+
+    public Map<PlanNodeId, TesseractAnalysisContext> getTableScanNodesToLocationInfo()
+    {
+        return tableScanNodesToLocationInfo;
     }
 
     public Statement getStatement()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
@@ -135,6 +135,7 @@ public class FeaturesConfig
     private boolean useTableScanNodePartitioning = true;
     private double tableScanNodePartitioningMinBucketToTaskRatio = 0.5;
     private boolean mergeProjectWithValues = true;
+    private boolean optimizeTesseractQueries = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
@@ -1086,6 +1087,18 @@ public class FeaturesConfig
     public FeaturesConfig setMergeProjectWithValues(boolean mergeProjectWithValues)
     {
         this.mergeProjectWithValues = mergeProjectWithValues;
+        return this;
+    }
+
+    public boolean isOptimizeTesseractQueries()
+    {
+        return optimizeTesseractQueries;
+    }
+
+    @Config("optimize-tesseract-queries")
+    public FeaturesConfig setOptimizeTesseractQueries(boolean optimizeTesseractQueries)
+    {
+        this.optimizeTesseractQueries = optimizeTesseractQueries;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizersFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizersFactory.java
@@ -24,6 +24,8 @@ public interface PlanOptimizersFactory
 {
     List<PlanOptimizer> get();
 
+    List<PlanOptimizer> getPrePlanningOptimizers();
+
     Map<Class<?>, OptimizerStats> getOptimizerStats();
 
     Map<Class<?>, RuleStats> getRuleStats();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -570,7 +570,8 @@ public class AddExchanges
                         typeOperators,
                         typeAnalyzer,
                         statsProvider,
-                        domainTranslator);
+                        domainTranslator,
+                        false);
                 if (plan.isPresent()) {
                     return new PlanWithProperties(plan.get(), derivePropertiesRecursively(plan.get()));
                 }

--- a/core/trino-main/src/main/java/tesseract/pojos/TesseractAnalysisContext.java
+++ b/core/trino-main/src/main/java/tesseract/pojos/TesseractAnalysisContext.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Tue, 01-03-2022
+ */
+package tesseract.pojos;
+
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.sql.tree.NodeLocation;
+
+/**
+ * Context to capture required details while traversing the analysis plan
+ */
+public class TesseractAnalysisContext
+{
+    NodeLocation nodeLocation;
+    QualifiedObjectName tableName;
+
+    public TesseractAnalysisContext()
+    {
+    }
+
+    public TesseractAnalysisContext(NodeLocation nodeLocation, QualifiedObjectName tableName)
+    {
+        this.nodeLocation = nodeLocation;
+        this.tableName = tableName;
+    }
+
+    public NodeLocation getNodeLocation()
+    {
+        return nodeLocation;
+    }
+
+    public void setNodeLocation(NodeLocation nodeLocation)
+    {
+        this.nodeLocation = nodeLocation;
+    }
+
+    public QualifiedObjectName getTableName()
+    {
+        return tableName;
+    }
+
+    public void setTableName(QualifiedObjectName tableName)
+    {
+        this.tableName = tableName;
+    }
+
+}

--- a/core/trino-main/src/main/java/tesseract/pojos/TesseractAnalysisTable.java
+++ b/core/trino-main/src/main/java/tesseract/pojos/TesseractAnalysisTable.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Thu, 03-02-2022
+ */
+package tesseract.pojos;
+
+import io.trino.spi.tesseract.TesseractTableInfo;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.tree.NodeLocation;
+
+import java.util.Comparator;
+
+/**
+ * Table structure for the tesseract cube detected in Analysis Plan
+ */
+public class TesseractAnalysisTable
+{
+
+    private static final Comparator<NodeLocation> nodeLocationComparator = Comparator.comparingInt(NodeLocation::getLineNumber).thenComparingInt(NodeLocation::getColumnNumber);
+
+    PlanNodeId planNodeId;
+    TesseractTableInfo tesseractTableInfo;
+    NodeLocation nodeLocation;
+
+    public TesseractAnalysisTable(PlanNodeId planNodeId, TesseractTableInfo tesseractTableInfo, NodeLocation nodeLocation)
+    {
+        this.planNodeId = planNodeId;
+        this.tesseractTableInfo = tesseractTableInfo;
+        this.nodeLocation = nodeLocation;
+    }
+
+    public PlanNodeId getPlanNodeId()
+    {
+        return planNodeId;
+    }
+
+    public TesseractTableInfo getTesseractTableInfo()
+    {
+        return tesseractTableInfo;
+    }
+
+    public NodeLocation getNodeLocation()
+    {
+        return nodeLocation;
+    }
+
+    public static Comparator<NodeLocation> getNodeLocationComparator()
+    {
+        return nodeLocationComparator;
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/pojos/TesseractAstContext.java
+++ b/core/trino-main/src/main/java/tesseract/pojos/TesseractAstContext.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Thu, 03-02-2022
+ */
+package tesseract.pojos;
+
+import io.trino.sql.tree.NodeLocation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+/**
+ * This is context object we maintain while traversing through the AST of a query
+ */
+public class TesseractAstContext
+{
+
+    /*
+    If a table has alias in a query then its location should override the location of table name in query
+    as we will need to insert the optimal predicate after the alias
+     */
+    NodeLocation aliasLocationInfo;
+
+    /*
+    While traversing a complex query containing multiple joins etc , this list stores the list of tables in a particular
+    select query section .
+     */
+    List<TesseractAstTable> querySpecificationLocalAstTables = new ArrayList<>();
+
+    /*
+    This stores all tesseract optimized tables in the complete AST ordered by their existence in the original query
+     */
+    Map<NodeLocation, TesseractAstTable> nodeLocationToTesseractAstTables = new TreeMap<>(TesseractAnalysisTable.getNodeLocationComparator());
+
+    public Optional<NodeLocation> getAliasLocationInfo()
+    {
+        return Optional.ofNullable(aliasLocationInfo);
+    }
+
+    public Map<NodeLocation, TesseractAstTable> getNodeLocationToTesseractAstTables()
+    {
+        return nodeLocationToTesseractAstTables;
+    }
+
+    public List<TesseractAstTable> getQuerySpecificationLocalAstTables()
+    {
+        return querySpecificationLocalAstTables;
+    }
+
+    public void setAliasLocationInfo(NodeLocation aliasLocationInfo)
+    {
+        this.aliasLocationInfo = aliasLocationInfo;
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/pojos/TesseractAstTable.java
+++ b/core/trino-main/src/main/java/tesseract/pojos/TesseractAstTable.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Thu, 03-02-2022
+ */
+package tesseract.pojos;
+
+import io.trino.sql.tree.NodeLocation;
+
+/**
+ * Table structure for a tesseract optimized table detected in a AST of original query
+ */
+public class TesseractAstTable {
+
+    /*
+     this captures the exact coordinate [line number & index at said line] where we'll have to insert the optimal predicate if required
+     */
+    NodeLocation nodeLocationForEdit;
+    NodeLocation originalNodeLocation;
+    String tableName;
+    boolean wherePresent;
+    String optimalPredicate;
+
+    public TesseractAstTable(NodeLocation nodeLocationForEdit, String tableName,NodeLocation originalNodeLocation) {
+        this.nodeLocationForEdit = nodeLocationForEdit;
+        this.tableName = tableName;
+        this.originalNodeLocation = originalNodeLocation;
+    }
+
+    public NodeLocation getOriginalNodeLocation()
+    {
+        return originalNodeLocation;
+    }
+
+    public NodeLocation getNodeLocationForEdit() {
+        return nodeLocationForEdit;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public boolean isWherePresent() {
+        return wherePresent;
+    }
+
+    public void setWherePresent(boolean wherePresent) {
+        this.wherePresent = wherePresent;
+    }
+
+    public String getOptimalPredicate()
+    {
+        return optimalPredicate;
+    }
+
+    public void setOptimalPredicate(String optimalPredicate)
+    {
+        this.optimalPredicate = optimalPredicate;
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/pojos/TesseractViewContext.java
+++ b/core/trino-main/src/main/java/tesseract/pojos/TesseractViewContext.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Fri, 04-03-2022
+ */
+package tesseract.pojos;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Context to capture details related to various views being referred in a query
+ */
+public class TesseractViewContext
+{
+
+    Set<TesseractViewRewriteInfo> viewLocationToRewriteInfo;
+    boolean referringTesseractTable;
+
+    public TesseractViewContext()
+    {
+        this.viewLocationToRewriteInfo = new TreeSet<>((view1, view2) -> {
+            int compareLine = Integer.compare(view1.getStartOfViewIdentifier().getLineNumber(), view2.getStartOfViewIdentifier().getLineNumber());
+            if (compareLine != 0) {
+                return compareLine;
+            }
+            else {
+                return Integer.compare(view1.getStartOfViewIdentifier().getColumnNumber(), view2.getStartOfViewIdentifier().getColumnNumber());
+            }
+        });
+    }
+
+    public Set<TesseractViewRewriteInfo> getViewLocationToRewriteInfo()
+    {
+        return viewLocationToRewriteInfo;
+    }
+
+    public void setViewLocationToRewriteInfo(Set<TesseractViewRewriteInfo> viewLocationToRewriteInfo)
+    {
+        this.viewLocationToRewriteInfo = viewLocationToRewriteInfo;
+    }
+
+    public boolean isReferringTesseractTable()
+    {
+        return referringTesseractTable;
+    }
+
+    public void setReferringTesseractTable(boolean referringTesseractTable)
+    {
+        this.referringTesseractTable = referringTesseractTable;
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/pojos/TesseractViewRewriteInfo.java
+++ b/core/trino-main/src/main/java/tesseract/pojos/TesseractViewRewriteInfo.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Fri, 04-03-2022
+ */
+package tesseract.pojos;
+
+import io.trino.sql.tree.NodeLocation;
+
+/**
+ * Details required to unfold a particular view
+ */
+public class TesseractViewRewriteInfo
+{
+
+    /*
+    Say for a query : { select * from hive."default"     ."table_name" groupby some_col }
+        - startOfViewIdentifier : will be node location of start of keyword {hive} in the original query
+        - endOfViewIdentifier : will be node location of start of keyword {"table_name"} in the original query
+        - endOfIdentifierLength : this is the length of the string {"table_name"} (including quotes)
+        - viewDefinition : this is the actual view definition of the trino view
+     */
+
+    NodeLocation startOfViewIdentifier;
+    NodeLocation endOfViewIdentifier;
+    Integer endOfIdentifierLength;
+    String viewDefinition;
+
+    public TesseractViewRewriteInfo(NodeLocation startOfViewIdentifier, NodeLocation endOfViewIdentifier, Integer endOfIdentifierLength, String viewDefinition)
+    {
+        this.startOfViewIdentifier = startOfViewIdentifier;
+        this.endOfViewIdentifier = endOfViewIdentifier;
+        this.endOfIdentifierLength = endOfIdentifierLength;
+        this.viewDefinition = viewDefinition;
+    }
+
+    public NodeLocation getStartOfViewIdentifier()
+    {
+        return startOfViewIdentifier;
+    }
+
+    public void setStartOfViewIdentifier(NodeLocation startOfViewIdentifier)
+    {
+        this.startOfViewIdentifier = startOfViewIdentifier;
+    }
+
+    public NodeLocation getEndOfViewIdentifier()
+    {
+        return endOfViewIdentifier;
+    }
+
+    public void setEndOfViewIdentifier(NodeLocation endOfViewIdentifier)
+    {
+        this.endOfViewIdentifier = endOfViewIdentifier;
+    }
+
+    public Integer getEndOfIdentifierLength()
+    {
+        return endOfIdentifierLength;
+    }
+
+    public void setEndOfIdentifierLength(Integer endOfIdentifierLength)
+    {
+        this.endOfIdentifierLength = endOfIdentifierLength;
+    }
+
+    public String getViewDefinition()
+    {
+        return viewDefinition;
+    }
+
+    public void setViewDefinition(String viewDefinition)
+    {
+        this.viewDefinition = viewDefinition;
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/visitor/TesseractAnalysisVisitor.java
+++ b/core/trino-main/src/main/java/tesseract/visitor/TesseractAnalysisVisitor.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Tue, 01-03-2022
+ */
+package tesseract.visitor;
+
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.sql.tree.DefaultTraversalVisitor;
+import io.trino.sql.tree.Table;
+import tesseract.pojos.TesseractAnalysisContext;
+
+import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+
+/**
+ * Visitor to traverse the analysis plan and capture node locations of tablescannode in the AST.
+ * These node locations are later on required to identify which optimal predicate belongs to what tablescan node in the original AST of query
+ */
+public class TesseractAnalysisVisitor
+        extends DefaultTraversalVisitor<TesseractAnalysisContext>
+{
+
+    private final Session session;
+
+    public TesseractAnalysisVisitor(Session session)
+    {
+        this.session = session;
+    }
+
+    @Override
+    protected Void visitTable(Table node, TesseractAnalysisContext context)
+    {
+        QualifiedObjectName name = createQualifiedObjectName(session, node, node.getName());
+        context.setNodeLocation(node.getLocation().get());
+        context.setTableName(name);
+
+        return super.visitTable(node, context);
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/visitor/TesseractAstVisitor.java
+++ b/core/trino-main/src/main/java/tesseract/visitor/TesseractAstVisitor.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Thu, 03-02-2022
+ */
+package tesseract.visitor;
+
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.tesseract.TesseractTableInfo;
+import io.trino.sql.tree.AliasedRelation;
+import io.trino.sql.tree.DefaultTraversalVisitor;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.QuerySpecification;
+import io.trino.sql.tree.Table;
+import io.trino.sql.tree.WindowDefinition;
+import tesseract.pojos.TesseractAstContext;
+import tesseract.pojos.TesseractAstTable;
+
+import java.util.Optional;
+
+import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+
+/**
+ * Responsible to traverse the AST of the original query and collect tesseract optimized tables and their required info.
+ */
+public class TesseractAstVisitor
+        extends DefaultTraversalVisitor<TesseractAstContext>
+{
+
+    private final Metadata metadata;
+    private final Session session;
+
+    public TesseractAstVisitor(Metadata metadata, Session session)
+    {
+        this.metadata = metadata;
+        this.session = session;
+    }
+
+    @Override
+    protected Void visitTable(Table node, TesseractAstContext context)
+    {
+
+        NodeLocation currentLocationInfo;
+        /*
+         if alias is present then it will override the table location
+         */
+        if (context.getAliasLocationInfo().isPresent()) {
+            currentLocationInfo = context.getAliasLocationInfo().get();
+        }
+        else {
+            int offset = 0;
+            Identifier tableIdentifier = node.getName().getOriginalParts().get(node.getName().getOriginalParts().size() - 1);
+            //enclosed by quotes
+            if (tableIdentifier.isDelimited()) {
+                offset += 2;
+            }
+            offset += tableIdentifier.getValue().length();
+            currentLocationInfo = getRightBoundedLocationInfo(tableIdentifier.getLocation().get(), offset);
+        }
+
+        QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getName());
+        Optional<TableHandle> optionalTable = metadata.getTableHandle(session, tableName);
+        if (optionalTable.isPresent()) {
+
+            Optional<TesseractTableInfo> tesseractTableInfo = optionalTable.get().getConnectorHandle().getTesseractTableInfo();
+
+            if (tesseractTableInfo.isPresent() && tesseractTableInfo.get().isTesseractOptimizedTable()) {
+                context.getQuerySpecificationLocalAstTables().add(
+                        new TesseractAstTable(currentLocationInfo, node.getName().getSuffix(), node.getLocation().get()));
+            }
+        }
+        /*
+         we only require alias info local to a table , a sub query's alias should not be visible to outer table
+         */
+        context.setAliasLocationInfo(null);
+        return super.visitTable(node, context);
+    }
+
+    /**
+     * If there is a alias present for a table then capture its location as it will be required
+     * to insert the optimal predicate later on
+     */
+    @Override
+    protected Void visitAliasedRelation(AliasedRelation node, TesseractAstContext context)
+    {
+        int offset = 0;
+        //enclosed by quotes
+        if (node.getAlias().isDelimited()) {
+            offset += 2;
+        }
+
+        offset += node.getAlias().getValue().length();
+        context.setAliasLocationInfo(getRightBoundedLocationInfo(node.getAlias().getLocation().get(), offset));
+        return super.visitAliasedRelation(node, context);
+    }
+
+    @Override
+    protected Void visitQuerySpecification(QuerySpecification node, TesseractAstContext context)
+    {
+        process(node.getSelect(), context);
+        context.setAliasLocationInfo(null);
+        if (node.getFrom().isPresent()) {
+            process(node.getFrom().get(), context);
+        }
+        if (node.getWhere().isPresent()) {
+            context.getQuerySpecificationLocalAstTables().forEach(table -> table.setWherePresent(true));
+            process(node.getWhere().get(), context);
+        }
+        if (node.getGroupBy().isPresent()) {
+            process(node.getGroupBy().get(), context);
+        }
+        if (node.getHaving().isPresent()) {
+            process(node.getHaving().get(), context);
+        }
+        for (WindowDefinition windowDefinition : node.getWindows()) {
+            process(windowDefinition, context);
+        }
+        if (node.getOrderBy().isPresent()) {
+            process(node.getOrderBy().get(), context);
+        }
+        if (node.getOffset().isPresent()) {
+            process(node.getOffset().get(), context);
+        }
+        if (node.getLimit().isPresent()) {
+            process(node.getLimit().get(), context);
+        }
+        // all tesseract tables captured in the current query section should be added to the complete query's AST table list
+        context.getQuerySpecificationLocalAstTables().forEach(
+                localQuerySectionTable -> context.getNodeLocationToTesseractAstTables().put(localQuerySectionTable.getOriginalNodeLocation(), localQuerySectionTable)
+        );
+
+        // this section's tesseract tables are not required anymore
+        context.getQuerySpecificationLocalAstTables().clear();
+        return null;
+    }
+
+    private static NodeLocation getRightBoundedLocationInfo(NodeLocation nodeLocation, int offset)
+    {
+        return new NodeLocation(nodeLocation.getLineNumber(), nodeLocation.getColumnNumber() + offset);
+    }
+}

--- a/core/trino-main/src/main/java/tesseract/visitor/TesseractViewUnfoldVisitor.java
+++ b/core/trino-main/src/main/java/tesseract/visitor/TesseractViewUnfoldVisitor.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Thu, 03-03-2022
+ */
+package tesseract.visitor;
+
+import io.trino.Session;
+import io.trino.execution.QueryPreparer;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.tesseract.TesseractTableInfo;
+import io.trino.sql.tree.DefaultTraversalVisitor;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Table;
+import tesseract.pojos.TesseractViewContext;
+import tesseract.pojos.TesseractViewRewriteInfo;
+
+import java.util.Optional;
+
+import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+
+/**
+ * Visitor used to visit all the views in the AST of the original query
+ */
+public class TesseractViewUnfoldVisitor extends DefaultTraversalVisitor<TesseractViewContext>
+{
+
+    private final Metadata metadata;
+    private final Session session;
+    private final QueryPreparer queryPreparer;
+
+    public TesseractViewUnfoldVisitor(Metadata metadata, Session session, QueryPreparer queryPreparer)
+    {
+        this.metadata = metadata;
+        this.session = session;
+        this.queryPreparer = queryPreparer;
+    }
+
+    @Override
+    protected Void visitTable(Table node, TesseractViewContext context)
+    {
+
+        Identifier endOfTableIdentifier = node.getName().getOriginalParts().get(node.getName().getOriginalParts().size() - 1);
+        int totalLengthOfTableEnd = endOfTableIdentifier.isDelimited() ? endOfTableIdentifier.getValue().length() + 2 : endOfTableIdentifier.getValue().length();
+
+        Identifier startOfTableIdentifier = node.getName().getOriginalParts().get(0);
+
+        QualifiedObjectName name = createQualifiedObjectName(session, node, node.getName());
+        Optional<ConnectorViewDefinition> optionalView = metadata.getView(session, name);
+
+        if (optionalView.isPresent()) {
+            /*
+            Start a new traversal on the view definition and find if its referring a tesseract table
+             */
+            TesseractViewContext viewAstContext = new TesseractViewContext();
+            queryPreparer.prepareQuery(session,optionalView.get().getOriginalSql()).getStatement().accept(this, viewAstContext);
+
+            if(viewAstContext.isReferringTesseractTable()){
+                context.getViewLocationToRewriteInfo().add(new TesseractViewRewriteInfo(
+                        startOfTableIdentifier.getLocation().get(),
+                        endOfTableIdentifier.getLocation().get(),
+                        totalLengthOfTableEnd,
+                        optionalView.get().getOriginalSql())
+                );
+            }
+        }
+        else {
+            // this leg is only relevant for the visitor visting the view definition of a view and encounters the table in the view definition
+            QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getName());
+            Optional<TableHandle> optionalTable = metadata.getTableHandle(session, tableName);
+            if (optionalTable.isPresent()) {
+                Optional<TesseractTableInfo> tesseractTableInfo = optionalTable.get().getConnectorHandle().getTesseractTableInfo();
+                if (tesseractTableInfo.isPresent() && tesseractTableInfo.get().isTesseractOptimizedTable()) {
+                    context.setReferringTesseractTable(true);
+                }
+            }
+        }
+        return super.visitTable(node, context);
+    }
+
+
+
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -282,6 +282,11 @@ public interface ConnectorMetadata
     }
 
     /**
+     * initializes the RDBMS connection properties required to fetch tesseract metadata
+     */
+    default void initializeTesseractMetadataConfig(ConnectorSession session){}
+
+    /**
      * Renames the specified schema.
      */
     default void renameSchema(ConnectorSession session, String source, String target)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableHandle.java
@@ -13,10 +13,36 @@
  */
 package io.trino.spi.connector;
 
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.tesseract.TesseractTableInfo;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 /**
  * Represents a handle to a relation returned from the connector to the engine.
  * It will be used by the engine whenever given relation will be accessed.
  */
 public interface ConnectorTableHandle
 {
+
+    /**
+     *  To fetch table information like name, schema and properties etc . This is not a time consuming Op
+     */
+    default Optional<TesseractTableInfo> getTesseractTableInfo(){
+        return Optional.empty();
+    }
+
+    /**
+     *  Evaluates the optimal predicate for the partition column's required values , connects with tesseract metadata cache to do so
+     */
+    default Optional<String> getTesseractTableOptimalPredicate(Optional<Map<ColumnHandle, Domain>> partitionColDomains){
+        return Optional.empty();
+    }
+
+    default boolean refersTesseractPartitionColumn(Set<ColumnHandle> columns){
+        return false;
+    }
+
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/tesseract/TesseractTableInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/tesseract/TesseractTableInfo.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Sat, 05-02-2022
+ */
+package io.trino.spi.tesseract;
+
+
+import java.util.Map;
+
+/**
+ * Store commonly required info for a tesseract table
+ */
+public class TesseractTableInfo {
+
+
+    public static final String TESSERACT_OPTIMIZED_TABLE = "optimize-tesseract-queries";
+
+    private String schema;
+    private String tableName;
+    private Map<String, String> tableProperties;
+
+
+    public TesseractTableInfo(String schema,String tableName, Map<String, String> tableProperties) {
+        this.schema = schema;
+        this.tableName = tableName;
+        this.tableProperties = tableProperties;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public Map<String, String> getTableProperties() {
+        return tableProperties;
+    }
+
+    public void setTableProperties(Map<String, String> tableProperties) {
+        this.tableProperties = tableProperties;
+    }
+
+    public boolean isTesseractOptimizedTable(){
+        return Boolean.parseBoolean(this.getTableProperties().getOrDefault(TESSERACT_OPTIMIZED_TABLE,"false"));
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -783,6 +783,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void initializeTesseractMetadataConfig(ConnectorSession session)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.initializeTesseractMetadataConfig(session);
+        }
+    }
+
+    @Override
     public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle table, long limit)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -297,6 +297,15 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- tesseract -->
+
+        <dependency>
+            <groupId>com.airtel.africa</groupId>
+            <artifactId>tesseract-querymanager</artifactId>
+            <version>2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- for benchmark -->
         <dependency>
             <groupId>io.trino</groupId>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -146,6 +146,8 @@ public class HiveConfig
 
     private boolean legacyHiveViewTranslation;
 
+    private String tesseractConfigLocation;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1032,6 +1034,17 @@ public class HiveConfig
     public HiveConfig setLegacyHiveViewTranslation(boolean legacyHiveViewTranslation)
     {
         this.legacyHiveViewTranslation = legacyHiveViewTranslation;
+        return this;
+    }
+
+    public String getTesseractConfigLocation() {
+        return tesseractConfigLocation;
+    }
+
+    @Config("tesseract.metadata-config-location")
+    @ConfigDescription("config location of database json containing connection details for rdbms tesseract needs to connect to fetch cube metadata")
+    public HiveConfig setTesseractConfigLocation(String tesseractConfigLocation) {
+        this.tesseractConfigLocation = tesseractConfigLocation;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -256,6 +256,7 @@ import static io.trino.plugin.hive.util.Statistics.reduce;
 import static io.trino.plugin.hive.util.SystemTables.getSourceTableNameFromSystemTable;
 import static io.trino.spi.StandardErrorCode.INVALID_ANALYZE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
@@ -761,6 +762,16 @@ public class HiveMetadata
                 .build();
 
         metastore.createDatabase(new HiveIdentity(session), database);
+    }
+
+    @Override
+    public void initializeTesseractMetadataConfig(ConnectorSession session)
+    {
+        Optional<String> configLocation = HiveSessionProperties.getTesseractMetadataConfigLocation(session);
+        if (configLocation.isEmpty()){
+            throw new TrinoException(INVALID_SESSION_PROPERTY,"Tesseract metadata config location not specified in hive catalog");
+        }
+        TesseractMetadataConfig.initializeTesseractMetadataConfig(hdfsEnvironment,session,configLocation.get());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -29,6 +29,7 @@ import io.trino.spi.session.PropertyMetadata;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -99,6 +100,7 @@ public final class HiveSessionProperties
     private static final String DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT = "dynamic_filtering_probe_blocking_timeout";
     private static final String OPTIMIZE_SYMLINK_LISTING = "optimize_symlink_listing";
     private static final String LEGACY_HIVE_VIEW_TRANSLATION = "legacy_hive_view_translation";
+    private static final String TESSERACT_METADATA_CONFIG_LOCATION = "tesseract_metadata_config_location";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -410,6 +412,11 @@ public final class HiveSessionProperties
                         LEGACY_HIVE_VIEW_TRANSLATION,
                         "Use legacy Hive view translation mechanism",
                         hiveConfig.isLegacyHiveViewTranslation(),
+                        false),
+                stringProperty(
+                        TESSERACT_METADATA_CONFIG_LOCATION,
+                        "config location of database json containing connection details for rdbms tesseract needs to connect to fetch cube metadata",
+                        hiveConfig.getTesseractConfigLocation(),
                         false));
     }
 
@@ -689,4 +696,10 @@ public final class HiveSessionProperties
     {
         return session.getProperty(LEGACY_HIVE_VIEW_TRANSLATION, Boolean.class);
     }
+
+    public static Optional<String> getTesseractMetadataConfigLocation(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(TESSERACT_METADATA_CONFIG_LOCATION, String.class));
+    }
+
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TesseractMetadataConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TesseractMetadataConfig.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Wed, 09-02-2022
+ */
+package io.trino.plugin.hive;
+
+import com.airtel.africa.canvas.common.db.DBConfig;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+
+/**
+ * Singleton to store the connection details of the RDBMS containing tesseract's metadata
+ */
+public class TesseractMetadataConfig {
+
+    private static final Gson gson = new Gson();
+    private static volatile DBConfig.Properties properties = null;
+
+    public static void initializeTesseractMetadataConfig(HdfsEnvironment hdfsEnvironment, ConnectorSession session, String configLocation){
+
+        if(properties == null) {
+            synchronized (TesseractMetadataConfig.class) {
+                if(properties == null) {
+                    try (FileSystem fileSystem = hdfsEnvironment.getFileSystem(new HdfsEnvironment.HdfsContext(session), new Path(configLocation));
+                         FSDataInputStream dataInputStream = fileSystem.open(new Path(configLocation));
+                         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(dataInputStream));
+                         JsonReader jsonReader = new JsonReader(bufferedReader)) {
+
+                        Map<String, DBConfig.Properties> map = gson.fromJson(jsonReader, new TypeToken<Map<String, DBConfig.Properties>>() {
+                        }.getType());
+                        properties = map.get(DBConfig.Database.POSTGRES.getDatabase());
+
+                    } catch (IOException e) {
+                        throw new TrinoException(INVALID_SESSION_PROPERTY, "Invalid location URI: " + configLocation, e);
+                    }
+                }
+            }
+        }
+    }
+
+    public static DBConfig.Properties getTesseractMetadataStoreConnectionDetails(){
+        return properties;
+    }
+
+    private TesseractMetadataConfig(){}
+
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/HiveProcedureModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/HiveProcedureModule.java
@@ -33,5 +33,6 @@ public class HiveProcedureModule
         procedures.addBinding().toProvider(UnregisterPartitionProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(SyncPartitionMetadataProcedure.class).in(Scopes.SINGLETON);
         procedures.addBinding().toProvider(DropStatsProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(TesseractCacheRefreshProcedure.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/TesseractCacheRefreshProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/TesseractCacheRefreshProcedure.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Airtel International LLP (AILLP) under one
+ * or more contributor license agreements.
+ * The AILLP licenses this file to you under the AA License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author Akash Roy
+ * @department Big Data Analytics Airtel Africa
+ * @since Fri, 11-02-2022
+ */
+package io.trino.plugin.hive.procedure;
+
+import com.airtel.africa.canvas.tesseract.querymanager.manager.CubeMetadataCacheManager;
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveSessionProperties;
+import io.trino.plugin.hive.TesseractMetadataConfig;
+import io.trino.spi.TrinoException;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.procedure.Procedure;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static io.trino.spi.block.MethodHandleUtil.methodHandle;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * API to refresh the tesseract cache for a table
+ */
+public class TesseractCacheRefreshProcedure
+        implements Provider<Procedure>
+{
+    private static final MethodHandle TESSERACT_REFRESH_CACHE = methodHandle(
+            TesseractCacheRefreshProcedure.class,
+            "refreshTesseractCache",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            String.class);
+
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public TesseractCacheRefreshProcedure(HdfsEnvironment hdfsEnvironment)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "refresh_tesseract_cache",
+                ImmutableList.of(new Procedure.Argument("schema_name", VARCHAR), new Procedure.Argument("table_name", VARCHAR),
+                        new Procedure.Argument("action", VARCHAR)),
+                TESSERACT_REFRESH_CACHE.bindTo(this));
+    }
+
+    public void refreshTesseractCache(ConnectorSession session, String schemaName, String tableName, String action)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doRefreshTesseractCache(session, schemaName, tableName, Integer.valueOf(action));
+        }
+    }
+
+    private void doRefreshTesseractCache(ConnectorSession session, String schemaName, String tableName, Integer action)
+    {
+
+        initializeTesseractMetadataConfig(session);
+        try {
+            CubeMetadataCacheManager.refreshTesseractCubeMetadata(String.join(".", schemaName, tableName),
+                    action,
+                    TesseractMetadataConfig.getTesseractMetadataStoreConnectionDetails());
+        }
+        catch (Exception e) {
+            throw new TrinoException(GENERIC_USER_ERROR, String.format("Error while refreshing tesseract table : %s for action : %s", String.join(".", schemaName, tableName), action));
+        }
+    }
+
+    public void initializeTesseractMetadataConfig(ConnectorSession session)
+    {
+        Optional<String> configLocation = HiveSessionProperties.getTesseractMetadataConfigLocation(session);
+        if (configLocation.isEmpty()) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, "Tesseract metadata config location not specified in hive catalog");
+        }
+        TesseractMetadataConfig.initializeTesseractMetadataConfig(hdfsEnvironment, session, configLocation.get());
+    }
+}


### PR DESCRIPTION
Query Manager 

ISSUES
------------------

1. Late events are populated in lower gran as they are recieved , but they will be trasffered to a bigger gran when it execution is triggered .

2. If a higher gran is executed , hive metadata update failed , presto is restarted , now as the tesseract cache is loaded . trino will use bigger gran to show data but that data is not yet visible to trino

3. User has to indicate the granularity in which the data is required explicitly , maybe we can solve it using datetime dimension join .



Design Pointers
------------------

1. Filtering on cuboid or gran does not disable cube optimization (These will just narrow down the scope to choose relevant data from)

3. Using a comment "--tesseract.disable.optimization" will disable the optimizations for complete query



TODO's
------------------

1. Remember to communicate the required metadata format changes to be translated to api endpoint querymanager
2. Release notes for trino - canvas
3. modify build sh to add only selective jars in lib


Release Notes
------------------

1. session property "optimize-tesseract-queries" should be used to enable disable tesseract optimization session wide
2. new catalog property introduced tesseract.metadata-config-location